### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -21,7 +21,8 @@ jobs:
       contents: write # In order to upload artifacts to GitHub releases
       id-token: write # In order to request a JWT for AWS auth
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: oprypin/find-latest-tag@v1
         with:
           repository: ${{ matrix.repo }}
@@ -72,7 +73,8 @@ jobs:
       contents: write # In order to upload artifacts to GitHub releases
       id-token: write # In order to request a JWT for AWS auth
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
