### PR TITLE
Change the Nixpkgs version to v<YY><MM>.<count>.0

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -54,10 +54,10 @@ jobs:
             rolling-prefix: v0.1
           - repo: NixOS/nixpkgs
             branch: nixos-22.11
-            rolling-prefix: v22.11
+            rolling-prefix: v2211
           - repo: NixOS/nixpkgs
             branch: nixos-23.05
-            rolling-prefix: v23.5
+            rolling-prefix: v2305
           - repo: nix-community/home-manager
             branch: master
             rolling-prefix: v0.1


### PR DESCRIPTION
We don't want to encode the month as the minor version since that implies the November release (23.11) is backwards compatible with the May release (23.5). So better to encode it as v2305 and v2311.

The revcount should be stored as the minor version rather than the patch version, since commits to stable branches *can* add new functionality.
