### PR TITLE
Mirror home-manager 22.11 / 23.05

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -111,6 +111,13 @@ jobs:
             branch: nixos-23.05
             rolling-minor: 2305
 
+          - repo: nix-community/home-manager
+            branch: release-22.11
+            rolling-minor: 2211
+          - repo: nix-community/home-manager
+            branch: release-23.05
+            rolling-minor: 2305
+
     runs-on: ubuntu-latest
     permissions:
       contents: write # In order to upload artifacts to GitHub releases


### PR DESCRIPTION
The project's license is: MIT

- [x] I have listed the project's license above, and it allows distribution.
- [ ] The project has declined to publish on their own.
- [x] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.
