### PR TITLE
mirror the "nixos-yymm-small" branch of nixpkgs as 0.yymm-small.x.

### DIFF
--- a/.github/workflows/nixpkgs.yml
+++ b/.github/workflows/nixpkgs.yml
@@ -28,7 +28,7 @@ jobs:
                 process.exit(1);
             }
             console.log(`Calculating the minor version for ${ref}`);
-            let regex = new RegExp(/^nixos-(?<version>([0-9]+\.[0-9]+)|unstable)$/);
+            let regex = new RegExp(/^nixos-(?<version>([0-9]+\.[0-9]+)(-small)?|unstable)$/);
             let match = regex.exec(ref);
             if (match && match.groups) {
                 const versionPart = match.groups.version;


### PR DESCRIPTION
Due to the `-small` branch getting fixes earlier than the normal branch of nixpkgs, it would be nice to have the small branch mirrored too, for environments like a devShell that I use at work. As such, this is a PR for doing exactly that: mirroring the `-small` branch of nixpkgs.

Checking with an online [semver comparision tool](https://semvercompare.azurewebsites.net/?version=0.2311.1&version=0.2311-small.1&version=0.1.0&version=0.1.1&version=0.2405.1&version=0.2405-small.1), `*.tar.gz` will still continue pointing to the normal, stable branch (`nixos-yy.mm`) and not the small branch.

Resolves #17.