### PR TITLE
Add home-manager 24.05

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -125,6 +125,11 @@ jobs:
             rolling-minor: 2305
             too-big: true
             run-on: UbuntuLatest32Cores128G
+          - repo: nix-community/home-manager
+            branch: release-24.05
+            rolling-minor: 2405
+            too-big: true
+            run-on: UbuntuLatest32Cores128G
 
     runs-on: ${{ matrix.run-on || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
The project's license is: (REPLACE WITH THE LICENSE)

- [ ] I have listed the project's license above, and it allows distribution.
- [ ] The project has declined to publish on their own.
- [ ] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.
