### PR TITLE
Bring back large runner for home-manager

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -116,6 +116,7 @@ jobs:
             branch: release-24.05
             rolling-minor: 2405
             too-big: true
+            run-on: UbuntuLatest32Cores128G
 
     runs-on: ${{ matrix.run-on || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
Even though too-big will let it complete, it's still fairly big, it seems.

The project's license is: (REPLACE WITH THE LICENSE)

- [ ] I have listed the project's license above, and it allows distribution.
- [ ] The project has declined to publish on their own.
- [ ] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.
