### PR TITLE
Add flake-parts and git-hooks nix project

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -67,6 +67,8 @@ jobs:
       matrix:
         include:
           # Please keep this sorted.
+          - repo: cachix/git-hooks.nix
+            branch: master
           - repo: cole-h/nixos-config
             branch: darwin
           - repo: danth/stylix
@@ -75,6 +77,8 @@ jobs:
             branch: main
           - repo: Gerschtli/nix-formatter-pack
             branch: master
+          - repo: hercules-ci/flake-parts
+            branch: main
           - repo: Mic92/sops-nix
             branch: master
           - repo: nix-community/dream2nix


### PR DESCRIPTION
The project's license is:
cachix/git-hooks.nix - Apache 2.0
hercules-ci/flake-parts - MIT

- [X] I have listed the project's license above, and it allows distribution.
- [X] The project has declined to publish on their own.
- [X] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.
