### PR TITLE
Change GitHub org for stylix project

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -71,7 +71,7 @@ jobs:
             branch: master
           - repo: cole-h/nixos-config
             branch: darwin
-          - repo: danth/stylix
+          - repo: nix-community/stylix
             branch: master
           - repo: DeterminateSystems/nix-netboot-serve
             branch: main


### PR DESCRIPTION
This has been moved into nix-community. I'm not sure how to handle past releases and am open to suggestion.
