### PR TITLE
Mirror nix-community/nixpkgs-terraform-providers-bin

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -74,6 +74,8 @@ jobs:
             branch: darwin
           - repo: nix-community/stylix
             branch: master
+          - repo: nix-community/nixpkgs-terraform-providers-bin
+            branch: master
           - repo: DeterminateSystems/nix-netboot-serve
             branch: main
           - repo: Gerschtli/nix-formatter-pack


### PR DESCRIPTION
The project's license is: (REPLACE WITH THE LICENSE)

- [ ] I have listed the project's license above, and it allows distribution.
- [ ] The project has declined to publish on their own.
- [ ] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the mirroring configuration to include an additional repository across both tag and rolling workflows.
  * This update affects internal automation only and does not change any user-facing functionality or interfaces.
  * No action required from users; behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->