### PR TITLE
Add NixOS 26.05 releases to mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -145,6 +145,10 @@ jobs:
             branch: nixos-25.11
             rolling-minor: 2511
 
+          - repo: NixOS/nixpkgs
+            branch: nixos-26.05
+            rolling-minor: 2605
+
           - repo: nix-darwin/nix-darwin
             branch: nix-darwin-24.11
             rolling-minor: 2411
@@ -152,6 +156,10 @@ jobs:
           - repo: nix-darwin/nix-darwin
             branch: nix-darwin-25.05
             rolling-minor: 2505
+
+          - repo: nix-darwin/nix-darwin
+            branch: nix-darwin-26.05
+            rolling-minow: 2605
 
           - repo: nix-community/home-manager
             branch: release-24.05
@@ -174,6 +182,12 @@ jobs:
           - repo: nix-community/home-manager
             branch: release-25.11
             rolling-minor: 2511
+            too-big: true
+            run-on: UbuntuLatest32Cores128G
+
+          - repo: nix-community/home-manager
+            branch: release-26.05
+            rolling-minor: 2605
             too-big: true
             run-on: UbuntuLatest32Cores128G
 


### PR DESCRIPTION
Marked as a draft until the release happens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for new 26.05 release series targets to the workflow matrix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/flakehub-mirror/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->