### PR TITLE
Remove hjem mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -124,8 +124,6 @@ jobs:
             branch: master
           - repo: pyproject-nix/build-system-pkgs
             branch: master
-          - repo: feel-co/hjem
-            branch: main
 
           # Pulled out of the alpha-sorted list, since they're handled special
           # in the rapid, fast-acting update handling.


### PR DESCRIPTION
As mentioned in https://github.com/DeterminateSystems/flakehub-mirror/pull/140#issuecomment-4128477349, we would prefer this not be mirrored on flakehub. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->