### PR TITLE
Mirror nlewo/nix2container

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -107,6 +107,8 @@ jobs:
             branch: nixos-unstable
           - repo: NixOS/nixos-hardware
             branch: master
+          - repo: nlewo/nix2container
+            branch: master
           - repo: numtide/flake-utils
             branch: main
           - repo: numtide/treefmt-nix


### PR DESCRIPTION
The project's license is: AGPL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include an additional repository in the mirroring process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->