### PR TITLE
Chill nixpkgs for -weekly

### DIFF
--- a/.github/workflows/buffered-nixpkgs.yml
+++ b/.github/workflows/buffered-nixpkgs.yml
@@ -13,6 +13,7 @@ jobs:
           - name: DeterminateSystems/nixpkgs-weekly
             repo: NixOS/nixpkgs
             branch: nixpkgs-unstable
+            prefix: 0.1.
 
     runs-on: ubuntu-latest
     permissions:
@@ -22,11 +23,37 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
-      - name: Checkout
+      - name: Checkout flakehub-mirror tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: flakehub-mirror-tooling
+          persist-credentials: false
+
+      - name: Calculate the revision to mirror
+        id: chill
+        working-directory: flakehub-mirror-tooling
+        env:
+          PREFIX: ${{ matrix.prefix }}
+        run: ./chill.sh "$PREFIX"
+
+      - name: Ensure a revision was calculated
+        env:
+          REVISION: ${{ steps.chill.outputs.revision }}
+          PREFIX: ${{ matrix.prefix }}
+        run: |
+          if [ -z "$REVISION" ]; then
+            echo "::error::chill.sh did not produce a revision for prefix '$PREFIX'" >&2
+            exit 1
+          fi
+
+      - name: Remove the tooling checkout to avoid conflicting with ${{ matrix.repo }}
+        run: rm -rf flakehub-mirror-tooling
+
+      - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ matrix.repo }}
-          ref: ${{ matrix.branch }}
+          ref: ${{ steps.chill.outputs.revision }}
           persist-credentials: false
 
       - name: Release to FlakeHub

--- a/chill.jq
+++ b/chill.jq
@@ -1,0 +1,10 @@
+def older_than_days($days):
+  (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) < (now - ($days * 86400));
+
+.[]
+| select(.version | startswith($prefix))
+| select(.visibility)
+| select(.yanked_at == null)
+| select(.published_at | older_than_days($chill_days))
+
+

--- a/chill.sh
+++ b/chill.sh
@@ -21,7 +21,7 @@ max_iterations=1000
 while [ "$iterations" -lt "$max_iterations" ]; do
   iterations=$((iterations + 1))
 
-  curl "https://api.flakehub.com/f/NixOS/nixpkgs/releases?offset=$offset" > "$scratch/releases.json"
+  curl --fail --max-time 30 "https://api.flakehub.com/f/NixOS/nixpkgs/releases?offset=$offset" > "$scratch/releases.json"
 
   if jq --exit-status \
     --argjson chill_days "$chill_days" \
@@ -43,7 +43,11 @@ if [ "$iterations" -ge "$max_iterations" ]; then
   exit 1
 fi
 
-if [ -s "$scratch/chilled.json" ]; then
-jq -r --slurp 'first' "$scratch/chilled.json"
-  jq -r --slurp 'first | "revision=" +.revision' "$scratch/chilled.json" >> "$GITHUB_OUTPUT"
+if [ ! -s "$scratch/chilled.json" ]; then
+  echo "::error::No matching release found after successful jq filter (empty output)" >&2
+  exit 1
 fi
+
+jq -r --slurp 'first' "$scratch/chilled.json"
+jq -r --slurp 'first | "revision=" +.revision' "$scratch/chilled.json" >> "$GITHUB_OUTPUT"
+

--- a/chill.sh
+++ b/chill.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eux
+
+prefix=$1
+chill_days=7
+
+if [ -z "${GITHUB_OUTPUT+x}" ] || [ -z "$GITHUB_OUTPUT" ]; then
+  GITHUB_OUTPUT=/dev/stdout
+fi
+
+scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
+function finish {
+  rm -rf "$scratch"
+}
+trap finish EXIT
+
+offset=0
+while true; do
+  curl "https://api.flakehub.com/f/NixOS/nixpkgs/releases?offset=$offset" > "$scratch/releases.json"
+  offset=$(cat "$scratch/releases.json" | jq 'map(.index) | last')
+
+  if jq --exit-status \
+    --argjson chill_days "$chill_days" \
+    --arg prefix "$prefix" \
+    --from-file ./chill.jq \
+    "$scratch/releases.json" > "$scratch/chilled.json"; then
+    break
+  fi
+done
+
+if [ -s "$scratch/chilled.json" ]; then
+jq -r --slurp 'first' "$scratch/chilled.json"
+  jq -r --slurp 'first | "revision=" +.revision' "$scratch/chilled.json" >> "$GITHUB_OUTPUT"
+fi

--- a/chill.sh
+++ b/chill.sh
@@ -16,9 +16,12 @@ function finish {
 trap finish EXIT
 
 offset=0
-while true; do
+iterations=0
+max_iterations=1000
+while [ "$iterations" -lt "$max_iterations" ]; do
+  iterations=$((iterations + 1))
+
   curl "https://api.flakehub.com/f/NixOS/nixpkgs/releases?offset=$offset" > "$scratch/releases.json"
-  offset=$(cat "$scratch/releases.json" | jq 'map(.index) | last')
 
   if jq --exit-status \
     --argjson chill_days "$chill_days" \
@@ -27,7 +30,18 @@ while true; do
     "$scratch/releases.json" > "$scratch/chilled.json"; then
     break
   fi
+
+  offset=$(cat "$scratch/releases.json" | jq 'map(.index) | last')
+  if [ -z "$offset" ] || [ "$offset" = "null" ]; then
+    echo "Reached end of pagination without finding a chilled release" >&2
+    exit 1
+  fi
 done
+
+if [ "$iterations" -ge "$max_iterations" ]; then
+  echo "Exceeded maximum pagination iterations ($max_iterations) without finding a chilled release" >&2
+  exit 1
+fi
 
 if [ -s "$scratch/chilled.json" ]; then
 jq -r --slurp 'first' "$scratch/chilled.json"


### PR DESCRIPTION
This implements a chilling period for nixpkgs before it enters nixpkgs-weekly. Instead of directly replicating nixpkgs' latest version, it uses `NixOS/nixpkgs` on FlakeHub to identify the most recent release that is at least 7 days old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the mirror buffering workflow to derive the target Nixpkgs revision dynamically from Flakehub release metadata (using the matrix prefix) and use it for the mirror release checkout.
  * Added a release-selection helper that filters releases by version prefix, visibility, not-yanked status, and age threshold (default: 7 days).
  * Improved workflow robustness with pagination retry handling and validation that the computed revision is non-empty before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->