### PR TITLE
Add 26.05 in an authenticated way

### DIFF
--- a/.github/workflows/buffered-nixpkgs.yml
+++ b/.github/workflows/buffered-nixpkgs.yml
@@ -19,7 +19,7 @@ jobs:
             repo: NixOS/nixpkgs
             branch: nixos-26.05
             prefix: 0.2605.
-            visibility: authenticated
+            visibility: public # but requires authentication
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/buffered-nixpkgs.yml
+++ b/.github/workflows/buffered-nixpkgs.yml
@@ -19,7 +19,7 @@ jobs:
             repo: NixOS/nixpkgs
             branch: nixos-26.05
             prefix: 0.2605.
-            visibility: public # but requires authentication
+            visibility: public
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/buffered-nixpkgs.yml
+++ b/.github/workflows/buffered-nixpkgs.yml
@@ -14,6 +14,12 @@ jobs:
             repo: NixOS/nixpkgs
             branch: nixpkgs-unstable
             prefix: 0.1.
+            visibility: public
+          - name: DeterminateSystems/nixpkgs-26.05-chilled
+            repo: NixOS/nixpkgs
+            branch: nixos-26.05
+            prefix: 0.2605.
+            visibility: authenticated
 
     runs-on: ubuntu-latest
     permissions:
@@ -61,7 +67,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           mirror: true
-          visibility: public
+          visibility: ${{ matrix.visibility }}
           repository: ${{ matrix.repo }}
           rolling: true
           rolling-minor: ${{ matrix.rolling-minor }}


### PR DESCRIPTION
The project's license is: (REPLACE WITH THE LICENSE)

- [ ] I have listed the project's license above, and it allows distribution.
- [ ] The project has declined to publish on their own.
- [ ] The project doesn't do versioned releases, OR the project was added to the versioned release mirror step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to apply FlakeHub visibility settings per mirrored repository using the build matrix. Both the weekly NixOS/nixpkgs mirror and the nixos-26.05 chilled branch are now configured for public visibility, and the FlakeHub push step uses the matrix-defined value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->